### PR TITLE
feat(pools): pool JDBC connections and complete the testkit providers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
     <module>oracle</module>
     <module>clickhouse</module>
     <module>duckdb</module>
+    <module>pools</module>
     <module>testkit</module>
   </modules>
 

--- a/pools/api/pom.xml
+++ b/pools/api/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.jdbc.datasource.pools</artifactId>
+    <version>${revision}</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>org.eclipse.daanse.jdbc.datasource.pools.api</artifactId>
+  <name>Daanse JDBC DataSource Connection Pool API</name>
+  <description>Service contract for pooled JDBC connections: the ConnectionPool type an OLAP context binds, plus the configuration attributes every pool implementation shares.</description>
+
+  <dependencies>
+  </dependencies>
+</project>

--- a/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/ConnectionPool.java
+++ b/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/ConnectionPool.java
@@ -1,0 +1,81 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.jdbc.datasource.pools.api;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Duration;
+
+import javax.sql.DataSource;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * A pool of physical connections over a {@link DataSource}, published as its own
+ * OSGi service type.
+ * <p>
+ * Deliberately not a {@link DataSource}: a consumer that binds a
+ * {@code ConnectionPool} cannot accidentally end up with an unpooled data source,
+ * whatever the target filter says. The distinction is carried by the type, not by
+ * configuration.
+ * <p>
+ * Implementations must block while the pool is exhausted rather than opening
+ * another physical connection - the whole point of the cap is that the database
+ * never sees more connections than it was told to expect.
+ */
+@ProviderType
+public interface ConnectionPool extends AutoCloseable {
+
+    /**
+     * Releases every physical connection the pool holds.
+     * <p>
+     * Under Declarative Services the component lifecycle takes care of this. It is
+     * declared for consumers that build a pool themselves - test harnesses and
+     * embedded use - because a pool that is dropped without being closed keeps its
+     * connections open on the database.
+     */
+    @Override
+    void close();
+
+    /**
+     * Takes a connection out of the pool, waiting for a free slot if the pool is
+     * exhausted. Closing the returned connection hands the slot back.
+     *
+     * @throws SQLException if no connection became available within
+     *                      {@link #acquireTimeout()}
+     */
+    Connection getConnection() throws SQLException;
+
+    /**
+     * As {@link #getConnection()}, but gives up after {@code timeout} even when the
+     * pool would wait longer. Callers that run under a statement deadline pass
+     * their remaining budget here, so a queue wait cannot silently outlive the
+     * query it belongs to.
+     */
+    Connection getConnection(Duration timeout) throws SQLException;
+
+    /**
+     * The pooled {@link DataSource} view, for consumers that only pass a data
+     * source on instead of opening connections themselves.
+     */
+    DataSource dataSource();
+
+    /** How long {@link #getConnection()} waits before giving up. */
+    Duration acquireTimeout();
+
+    /** Upper bound on physical connections this pool opens. */
+    int maxSize();
+
+    /** Physical connections currently handed out. Diagnostics only. */
+    int activeSize();
+}

--- a/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/Constants.java
+++ b/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/Constants.java
@@ -1,0 +1,70 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.jdbc.datasource.pools.api;
+
+import org.osgi.framework.Bundle;
+
+/**
+ * Configuration property names shared by every {@link ConnectionPool}
+ * implementation. The PIDs themselves live in the implementation {@link Bundle},
+ * because each one is configured separately.
+ */
+public class Constants {
+
+    private Constants() {
+    }
+
+    /** Marks a service as pooled; consumers can filter on it. */
+    public static final String POOL_PROPERTY_KIND = "org.eclipse.daanse.jdbc.datasource.pool.kind";
+
+    /** Target filter selecting the {@link javax.sql.DataSource} to pool. */
+    public static final String POOL_PROPERTY_DATASOURCE_TARGET = "dataSource.target";
+
+    /** Free-form name; ends up in the pool's thread names and in its metrics. */
+    public static final String POOL_PROPERTY_POOL_NAME = "poolName";
+
+    /**
+     * Upper bound on physical connections. Must clear the concurrency the engine
+     * actually produces - rolap runs up to
+     * {@code segmentCacheManagerNumberSqlThreads} statements at once per context,
+     * and several contexts may share one pool.
+     */
+    public static final String POOL_PROPERTY_MAX_SIZE = "maximumPoolSize";
+
+    /** Connections kept open while idle. */
+    public static final String POOL_PROPERTY_MIN_IDLE = "minimumIdle";
+
+    /** How long {@code getConnection()} waits for a free slot, in milliseconds. */
+    public static final String POOL_PROPERTY_ACQUIRE_TIMEOUT = "connectionTimeout";
+
+    /** Idle connections are evicted after this many milliseconds. */
+    public static final String POOL_PROPERTY_IDLE_TIMEOUT = "idleTimeout";
+
+    /** A connection is retired this many milliseconds after it was opened. */
+    public static final String POOL_PROPERTY_MAX_LIFETIME = "maxLifetime";
+
+    /**
+     * A connection held longer than this is reported (hikari) or reclaimed
+     * (dbcp2), in milliseconds; 0 disables it. Mondrian's own pool reclaimed after
+     * 300s, which is worth keeping in mind for the streaming paths that hold a
+     * connection for as long as a ResultSet is being read.
+     */
+    public static final String POOL_PROPERTY_LEAK_THRESHOLD = "leakThreshold";
+
+    public static final int DEFAULT_MAX_SIZE = 50;
+    public static final int DEFAULT_MIN_IDLE = 5;
+    public static final long DEFAULT_ACQUIRE_TIMEOUT = 30_000L;
+    public static final long DEFAULT_IDLE_TIMEOUT = 600_000L;
+    public static final long DEFAULT_MAX_LIFETIME = 1_800_000L;
+    public static final long DEFAULT_LEAK_THRESHOLD = 300_000L;
+}

--- a/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/ocd/BaseConfig.java
+++ b/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/ocd/BaseConfig.java
@@ -1,0 +1,85 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.jdbc.datasource.pools.api.ocd;
+
+import org.eclipse.daanse.jdbc.datasource.pools.api.Constants;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+
+/**
+ * The attributes every pool implementation shares. Implementation bundles extend
+ * this in their own {@code @ObjectClassDefinition} and add whatever their library
+ * offers on top.
+ */
+public interface BaseConfig {
+
+    String L10N_PREFIX = "%";
+    String L10N_POSTFIX_DESCRIPTION = ".description";
+    String L10N_POSTFIX_NAME = ".name";
+
+    String L10N_OCD_NAME = L10N_PREFIX + "ocd" + L10N_POSTFIX_NAME;
+    String L10N_OCD_DESCRIPTION = L10N_PREFIX + "ocd" + L10N_POSTFIX_DESCRIPTION;
+
+    String L10N_POOL_NAME_NAME = L10N_PREFIX + Constants.POOL_PROPERTY_POOL_NAME + L10N_POSTFIX_NAME;
+    String L10N_POOL_NAME_DESCRIPTION = L10N_PREFIX + Constants.POOL_PROPERTY_POOL_NAME + L10N_POSTFIX_DESCRIPTION;
+    String L10N_MAX_SIZE_NAME = L10N_PREFIX + Constants.POOL_PROPERTY_MAX_SIZE + L10N_POSTFIX_NAME;
+    String L10N_MAX_SIZE_DESCRIPTION = L10N_PREFIX + Constants.POOL_PROPERTY_MAX_SIZE + L10N_POSTFIX_DESCRIPTION;
+    String L10N_MIN_IDLE_NAME = L10N_PREFIX + Constants.POOL_PROPERTY_MIN_IDLE + L10N_POSTFIX_NAME;
+    String L10N_MIN_IDLE_DESCRIPTION = L10N_PREFIX + Constants.POOL_PROPERTY_MIN_IDLE + L10N_POSTFIX_DESCRIPTION;
+    String L10N_ACQUIRE_TIMEOUT_NAME = L10N_PREFIX + Constants.POOL_PROPERTY_ACQUIRE_TIMEOUT + L10N_POSTFIX_NAME;
+    String L10N_ACQUIRE_TIMEOUT_DESCRIPTION = L10N_PREFIX + Constants.POOL_PROPERTY_ACQUIRE_TIMEOUT
+            + L10N_POSTFIX_DESCRIPTION;
+    String L10N_IDLE_TIMEOUT_NAME = L10N_PREFIX + Constants.POOL_PROPERTY_IDLE_TIMEOUT + L10N_POSTFIX_NAME;
+    String L10N_IDLE_TIMEOUT_DESCRIPTION = L10N_PREFIX + Constants.POOL_PROPERTY_IDLE_TIMEOUT
+            + L10N_POSTFIX_DESCRIPTION;
+    String L10N_MAX_LIFETIME_NAME = L10N_PREFIX + Constants.POOL_PROPERTY_MAX_LIFETIME + L10N_POSTFIX_NAME;
+    String L10N_MAX_LIFETIME_DESCRIPTION = L10N_PREFIX + Constants.POOL_PROPERTY_MAX_LIFETIME
+            + L10N_POSTFIX_DESCRIPTION;
+    String L10N_LEAK_THRESHOLD_NAME = L10N_PREFIX + Constants.POOL_PROPERTY_LEAK_THRESHOLD + L10N_POSTFIX_NAME;
+    String L10N_LEAK_THRESHOLD_DESCRIPTION = L10N_PREFIX + Constants.POOL_PROPERTY_LEAK_THRESHOLD
+            + L10N_POSTFIX_DESCRIPTION;
+
+    @AttributeDefinition(name = L10N_POOL_NAME_NAME, description = L10N_POOL_NAME_DESCRIPTION, required = false)
+    default String poolName() {
+        return "";
+    }
+
+    @AttributeDefinition(name = L10N_MAX_SIZE_NAME, description = L10N_MAX_SIZE_DESCRIPTION, required = false)
+    default int maximumPoolSize() {
+        return Constants.DEFAULT_MAX_SIZE;
+    }
+
+    @AttributeDefinition(name = L10N_MIN_IDLE_NAME, description = L10N_MIN_IDLE_DESCRIPTION, required = false)
+    default int minimumIdle() {
+        return Constants.DEFAULT_MIN_IDLE;
+    }
+
+    @AttributeDefinition(name = L10N_ACQUIRE_TIMEOUT_NAME, description = L10N_ACQUIRE_TIMEOUT_DESCRIPTION, required = false)
+    default long connectionTimeout() {
+        return Constants.DEFAULT_ACQUIRE_TIMEOUT;
+    }
+
+    @AttributeDefinition(name = L10N_IDLE_TIMEOUT_NAME, description = L10N_IDLE_TIMEOUT_DESCRIPTION, required = false)
+    default long idleTimeout() {
+        return Constants.DEFAULT_IDLE_TIMEOUT;
+    }
+
+    @AttributeDefinition(name = L10N_MAX_LIFETIME_NAME, description = L10N_MAX_LIFETIME_DESCRIPTION, required = false)
+    default long maxLifetime() {
+        return Constants.DEFAULT_MAX_LIFETIME;
+    }
+
+    @AttributeDefinition(name = L10N_LEAK_THRESHOLD_NAME, description = L10N_LEAK_THRESHOLD_DESCRIPTION, required = false)
+    default long leakThreshold() {
+        return Constants.DEFAULT_LEAK_THRESHOLD;
+    }
+}

--- a/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/ocd/package-info.java
+++ b/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/ocd/package-info.java
@@ -1,0 +1,16 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Stefan Bischof (bipolis.org) - initial
+*/
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("0.0.1")
+
+package org.eclipse.daanse.jdbc.datasource.pools.api.ocd;

--- a/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/package-info.java
+++ b/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/package-info.java
@@ -1,0 +1,16 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Stefan Bischof (bipolis.org) - initial
+*/
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("0.0.1")
+
+package org.eclipse.daanse.jdbc.datasource.pools.api;

--- a/pools/hikari/pom.xml
+++ b/pools/hikari/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 /*********************************************************************
-* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -16,32 +16,25 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eclipse.daanse</groupId>
-    <artifactId>org.eclipse.daanse.jdbc.datasource.testkit</artifactId>
+    <artifactId>org.eclipse.daanse.jdbc.datasource.pools</artifactId>
     <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>org.eclipse.daanse.jdbc.datasource.testkit.api</artifactId>
-  <name>Daanse JDBC DataSource Test Kit API</name>
-
-  <packaging>jar</packaging>
+  <artifactId>org.eclipse.daanse.jdbc.datasource.pools.hikari</artifactId>
+  <name>Daanse JDBC DataSource Connection Pool HikariCP</name>
+  <description>ConnectionPool implementation backed by HikariCP. Wraps a plain DataSource, so it does not depend on the driver firing PooledConnection close events.</description>
 
   <dependencies>
     <dependency>
       <groupId>org.eclipse.daanse</groupId>
       <artifactId>org.eclipse.daanse.jdbc.datasource.pools.api</artifactId>
-      <version>${revision}</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.daanse</groupId>
-      <artifactId>org.eclipse.daanse.jdbc.datasource.pools.hikari</artifactId>
-      <version>${revision}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.daanse</groupId>
-      <artifactId>org.eclipse.daanse.sql.dialect.api</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+      <version>7.1.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/pools/hikari/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/hikari/api/Constants.java
+++ b/pools/hikari/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/hikari/api/Constants.java
@@ -1,0 +1,33 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.jdbc.datasource.pools.hikari.api;
+
+import org.osgi.framework.Bundle;
+
+/**
+ * Constants of this {@link Bundle}.
+ */
+public class Constants {
+
+    private Constants() {
+    }
+
+    /** Value of the shared pool-kind service property. */
+    public static final String KIND = "hikari";
+
+    /**
+     * Factory PID. One configuration is one pool; several configurations over the
+     * same DataSource give several independent pools.
+     */
+    public static final String PID_CONNECTION_POOL = "daanse.jdbc.datasource.pools.hikari.ConnectionPool";
+}

--- a/pools/hikari/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/hikari/api/HikariConnectionPools.java
+++ b/pools/hikari/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/hikari/api/HikariConnectionPools.java
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.jdbc.datasource.pools.hikari.api;
+
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.eclipse.daanse.jdbc.datasource.pools.api.ConnectionPool;
+import org.eclipse.daanse.jdbc.datasource.pools.hikari.impl.HikariConnectionPool;
+
+/**
+ * Builds a {@link ConnectionPool} without Declarative Services.
+ * <p>
+ * In a running framework the pool arrives as a service and none of this is
+ * needed. This exists for the callers that wire a context by hand - test
+ * harnesses above all - so that they get the same pooling as production instead
+ * of handing rolap a bare DataSource, which opens one physical connection per
+ * statement.
+ * <p>
+ * The caller owns the returned pool and has to {@link ConnectionPool#close()} it.
+ */
+public final class HikariConnectionPools {
+
+    private HikariConnectionPools() {
+    }
+
+    /**
+     * @param dataSource the data source to pool
+     * @param config     pool properties as in {@link org.eclipse.daanse.jdbc.datasource.pools.api.Constants};
+     *                   an empty map takes every default
+     */
+    public static ConnectionPool create(DataSource dataSource, Map<String, Object> config) {
+        return new HikariConnectionPool(dataSource, config == null ? Map.of() : config);
+    }
+
+    /** As {@link #create(DataSource, Map)} with every default. */
+    public static ConnectionPool create(DataSource dataSource) {
+        return create(dataSource, Map.of());
+    }
+}

--- a/pools/hikari/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/hikari/api/ocd/DsConfig.java
+++ b/pools/hikari/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/hikari/api/ocd/DsConfig.java
@@ -1,0 +1,33 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.jdbc.datasource.pools.hikari.api.ocd;
+
+import org.eclipse.daanse.jdbc.datasource.pools.api.ocd.BaseConfig;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+@ObjectClassDefinition(name = BaseConfig.L10N_OCD_NAME, description = BaseConfig.L10N_OCD_DESCRIPTION, localization = DsConfig.OCD_LOCALIZATION)
+public interface DsConfig extends BaseConfig {
+
+    String OCD_LOCALIZATION = "OSGI-INF/l10n/org.eclipse.daanse.jdbc.datasource.pools.hikari.ocd";
+
+    String L10N_DATASOURCE_TARGET_NAME = L10N_PREFIX + "dataSource.target" + L10N_POSTFIX_NAME;
+    String L10N_DATASOURCE_TARGET_DESCRIPTION = L10N_PREFIX + "dataSource.target" + L10N_POSTFIX_DESCRIPTION;
+
+    /**
+     * Which DataSource service to pool. Required: without it the component would
+     * bind an arbitrary one.
+     */
+    @AttributeDefinition(name = L10N_DATASOURCE_TARGET_NAME, description = L10N_DATASOURCE_TARGET_DESCRIPTION)
+    String dataSource_target();
+}

--- a/pools/hikari/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/hikari/api/ocd/package-info.java
+++ b/pools/hikari/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/hikari/api/ocd/package-info.java
@@ -1,0 +1,16 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Stefan Bischof (bipolis.org) - initial
+*/
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("0.0.1")
+
+package org.eclipse.daanse.jdbc.datasource.pools.hikari.api.ocd;

--- a/pools/hikari/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/hikari/api/package-info.java
+++ b/pools/hikari/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/hikari/api/package-info.java
@@ -1,0 +1,16 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Stefan Bischof (bipolis.org) - initial
+*/
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("0.0.1")
+
+package org.eclipse.daanse.jdbc.datasource.pools.hikari.api;

--- a/pools/hikari/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/hikari/impl/HikariConnectionPool.java
+++ b/pools/hikari/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/hikari/impl/HikariConnectionPool.java
@@ -1,0 +1,195 @@
+/*
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Stefan Bischof (bipolis.org) - initial
+*/
+package org.eclipse.daanse.jdbc.datasource.pools.hikari.impl;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.sql.DataSource;
+
+import org.eclipse.daanse.jdbc.datasource.pools.api.ConnectionPool;
+import org.eclipse.daanse.jdbc.datasource.pools.api.Constants;
+import org.eclipse.daanse.jdbc.datasource.pools.hikari.api.ocd.DsConfig;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.osgi.service.metatype.annotations.Designate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+/**
+ * A {@link ConnectionPool} backed by HikariCP.
+ * <p>
+ * HikariCP pools the {@link DataSource} it is handed, rather than going through
+ * {@code ConnectionPoolDataSource}/{@code PooledConnection}. That matters here:
+ * not every driver fires the close event a {@code PooledConnection}-based pool
+ * reclaims on - MariaDB's does not, and a pool built that way leaks a physical
+ * connection per checkout. Wrapping the plain DataSource behaves the same on
+ * every driver.
+ * <p>
+ * No {@code @Modified}: a configuration change replaces the component, and the
+ * old pool is closed in {@link #deactivate()}.
+ */
+@Designate(ocd = DsConfig.class, factory = true)
+@Component(service = ConnectionPool.class, scope = ServiceScope.SINGLETON, //
+        configurationPid = org.eclipse.daanse.jdbc.datasource.pools.hikari.api.Constants.PID_CONNECTION_POOL, //
+        property = Constants.POOL_PROPERTY_KIND + "="
+                + org.eclipse.daanse.jdbc.datasource.pools.hikari.api.Constants.KIND)
+public class HikariConnectionPool implements ConnectionPool {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HikariConnectionPool.class);
+
+    private final HikariDataSource pool;
+    private final Duration acquireTimeout;
+    /** Only used by the deadline-bounded acquire path; virtual threads keep it cheap. */
+    private final ExecutorService acquireExecutor = Executors.newVirtualThreadPerTaskExecutor();
+
+    @Activate
+    public HikariConnectionPool(@Reference DataSource dataSource, Map<String, Object> config) {
+        HikariConfig cfg = new HikariConfig();
+        cfg.setDataSource(dataSource);
+        cfg.setPoolName(string(config, Constants.POOL_PROPERTY_POOL_NAME, "daanse-hikari"));
+        cfg.setMaximumPoolSize(integer(config, Constants.POOL_PROPERTY_MAX_SIZE, Constants.DEFAULT_MAX_SIZE));
+        cfg.setMinimumIdle(integer(config, Constants.POOL_PROPERTY_MIN_IDLE, Constants.DEFAULT_MIN_IDLE));
+        cfg.setConnectionTimeout(
+                number(config, Constants.POOL_PROPERTY_ACQUIRE_TIMEOUT, Constants.DEFAULT_ACQUIRE_TIMEOUT));
+        cfg.setIdleTimeout(number(config, Constants.POOL_PROPERTY_IDLE_TIMEOUT, Constants.DEFAULT_IDLE_TIMEOUT));
+        cfg.setMaxLifetime(number(config, Constants.POOL_PROPERTY_MAX_LIFETIME, Constants.DEFAULT_MAX_LIFETIME));
+        // Reports a connection held longer than this; unlike dbcp2 hikari never takes
+        // it back, so this is a warning about a caller that forgot to close, nothing more.
+        cfg.setLeakDetectionThreshold(
+                number(config, Constants.POOL_PROPERTY_LEAK_THRESHOLD, Constants.DEFAULT_LEAK_THRESHOLD));
+
+        this.acquireTimeout = Duration.ofMillis(cfg.getConnectionTimeout());
+        this.pool = new HikariDataSource(cfg);
+        LOGGER.info("pool {} up: max={} idleMin={} acquireTimeout={}ms", cfg.getPoolName(), cfg.getMaximumPoolSize(),
+                cfg.getMinimumIdle(), cfg.getConnectionTimeout());
+    }
+
+    @Deactivate
+    public void deactivate() {
+        close();
+    }
+
+    @Override
+    public void close() {
+        acquireExecutor.shutdownNow();
+        pool.close();
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return pool.getConnection();
+    }
+
+    @Override
+    public Connection getConnection(Duration timeout) throws SQLException {
+        if (timeout == null || timeout.compareTo(acquireTimeout) >= 0) {
+            return pool.getConnection();
+        }
+        // Hikari fixes its wait at construction time and offers no per-call deadline,
+        // so wait on another thread and give up on schedule here. A connection that
+        // turns up after we gave up is closed rather than leaked.
+        CompletableFuture<Connection> pending = CompletableFuture.supplyAsync(() -> {
+            try {
+                return pool.getConnection();
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        }, acquireExecutor);
+        try {
+            return pending.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            pending.thenAccept(HikariConnectionPool::closeQuietly);
+            throw new SQLException("no pooled connection within the caller's budget of " + timeout, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            pending.thenAccept(HikariConnectionPool::closeQuietly);
+            throw new SQLException("interrupted while waiting for a pooled connection", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            throw cause instanceof SQLException sql ? sql : new SQLException(cause);
+        }
+    }
+
+    private static void closeQuietly(Connection connection) {
+        if (connection == null) {
+            return;
+        }
+        try {
+            connection.close();
+        } catch (SQLException e) {
+            LOGGER.warn("could not return a connection that arrived after its caller gave up", e);
+        }
+    }
+
+    @Override
+    public DataSource dataSource() {
+        return pool;
+    }
+
+    @Override
+    public Duration acquireTimeout() {
+        return acquireTimeout;
+    }
+
+    @Override
+    public int maxSize() {
+        return pool.getMaximumPoolSize();
+    }
+
+    @Override
+    public int activeSize() {
+        return pool.getHikariPoolMXBean() == null ? 0 : pool.getHikariPoolMXBean().getActiveConnections();
+    }
+
+    private static String string(Map<String, Object> config, String key, String dflt) {
+        Object v = config.get(key);
+        return v == null || v.toString().isBlank() ? dflt : v.toString();
+    }
+
+    private static int integer(Map<String, Object> config, String key, int dflt) {
+        return (int) number(config, key, dflt);
+    }
+
+    private static long number(Map<String, Object> config, String key, long dflt) {
+        Object v = config.get(key);
+        if (v instanceof Number n) {
+            return n.longValue();
+        }
+        if (v != null) {
+            try {
+                return Long.parseLong(v.toString().trim());
+            } catch (NumberFormatException e) {
+                // A mistyped value must not silently become the default - that is exactly
+                // the trap ConfigConstants falls into elsewhere in this codebase.
+                LOGGER.warn("pool property {}={} is not a number, using {}", key, v, dflt);
+            }
+        }
+        return dflt;
+    }
+}

--- a/pools/hikari/src/main/resources/OSGI-INF/l10n/org.eclipse.daanse.jdbc.datasource.pools.hikari.ocd.properties
+++ b/pools/hikari/src/main/resources/OSGI-INF/l10n/org.eclipse.daanse.jdbc.datasource.pools.hikari.ocd.properties
@@ -1,0 +1,18 @@
+ocd.name=Daanse Connection Pool (HikariCP)
+ocd.description=Pools the physical connections of one DataSource. Several contexts may share one pool; the cap then applies to the database as a whole.
+dataSource.target.name=DataSource filter
+dataSource.target.description=OSGi target filter selecting the DataSource to pool, e.g. (daanse.ident=ds001).
+poolName.name=Pool name
+poolName.description=Shows up in thread names and metrics.
+maximumPoolSize.name=Maximum pool size
+maximumPoolSize.description=Upper bound on physical connections. Must clear the concurrency the engine produces: rolap runs up to segmentCacheManagerNumberSqlThreads statements at once per context, and contexts sharing this pool add up.
+minimumIdle.name=Minimum idle
+minimumIdle.description=Connections kept open while idle.
+connectionTimeout.name=Acquire timeout (ms)
+connectionTimeout.description=How long getConnection() waits for a free slot before failing.
+idleTimeout.name=Idle timeout (ms)
+idleTimeout.description=Idle connections above the minimum are evicted after this time.
+maxLifetime.name=Maximum lifetime (ms)
+maxLifetime.description=A connection is retired this long after it was opened.
+leakThreshold.name=Leak report threshold (ms)
+leakThreshold.description=A connection held longer than this is reported. HikariCP only warns and never takes it back; use the dbcp2 pool if connections must be reclaimed.

--- a/pools/pom.xml
+++ b/pools/pom.xml
@@ -20,28 +20,13 @@
     <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>org.eclipse.daanse.jdbc.datasource.testkit</artifactId>
+  <artifactId>org.eclipse.daanse.jdbc.datasource.pools</artifactId>
   <packaging>pom</packaging>
-  <name>Daanse JDBC DataSource Test Kit (aggregator)</name>
-  <description>Aggregator for the cross-repo testkit SPI + DB provider
-    implementations. Consumers depend on
-    org.eclipse.daanse.jdbc.datasource.testkit.api for the SPI types,
-    and on one or more of testkit.h2 / testkit.postgresql / testkit.mysql
-    / testkit.mssqlserver for the ServiceLoader-registered providers
-    that boot the actual database.</description>
+  <name>Daanse JDBC DataSource Connection Pools</name>
+  <description>Connection pool contract and implementations that wrap a plain DataSource.</description>
 
   <modules>
     <module>api</module>
-    <module>h2</module>
-    <module>postgresql</module>
-    <module>mysql</module>
-    <module>mssqlserver</module>
-    <module>mariadb</module>
-    <module>oracle</module>
-    <module>sqlite</module>
-    <module>duckdb</module>
-    <module>derby</module>
-    <module>clickhouse</module>
-    <module>empty</module>
+    <module>hikari</module>
   </modules>
 </project>

--- a/testkit/api/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/api/ActiveDatabase.java
+++ b/testkit/api/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/api/ActiveDatabase.java
@@ -12,12 +12,44 @@
  */
 package org.eclipse.daanse.jdbc.datasource.testkit.api;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.sql.DataSource;
 
+import org.eclipse.daanse.jdbc.datasource.pools.api.ConnectionPool;
+import org.eclipse.daanse.jdbc.datasource.pools.hikari.api.HikariConnectionPools;
 import org.eclipse.daanse.sql.dialect.api.Dialect;
 
 /**
- * Pair of a live {@link DataSource} and the matching {@link Dialect}.
+ * A live {@link DataSource}, the matching {@link Dialect}, and a
+ * {@link ConnectionPool} over that data source.
+ * <p>
+ * The pool is part of the record because consumers of this testkit drive rolap,
+ * which opens one physical connection per statement. Handing them a bare
+ * DataSource is what exhausted ephemeral ports on MariaDB, server processes on
+ * Oracle and table locks on SQLite; every consumer getting a pooled handle by
+ * default is the point.
+ * <p>
+ * The pool belongs to whoever created the record - normally the
+ * {@link DatabaseProvider}, which caches its databases and should close them.
  */
-public record ActiveDatabase(DataSource dataSource, Dialect dialect) {
+public record ActiveDatabase(DataSource dataSource, Dialect dialect, ConnectionPool connectionPool) {
+
+    /** Wraps {@code dataSource} in a pool. */
+    public ActiveDatabase(DataSource dataSource, Dialect dialect) {
+        this(dataSource, dialect, HikariConnectionPools.create(dataSource, poolConfig()));
+    }
+
+    /**
+     * Pool settings for test runs, overridable per run:
+     * {@code -Ddaanse.test.pool.maxSize=30 -Ddaanse.test.pool.minIdle=1}.
+     */
+    private static Map<String, Object> poolConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("maximumPoolSize", Integer.getInteger("daanse.test.pool.maxSize", 30));
+        config.put("minimumIdle", Integer.getInteger("daanse.test.pool.minIdle", 1));
+        config.put("connectionTimeout", Long.getLong("daanse.test.pool.timeoutMs", 60_000L));
+        return config;
+    }
 }

--- a/testkit/clickhouse/pom.xml
+++ b/testkit/clickhouse/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.jdbc.datasource.testkit</artifactId>
+    <version>${revision}</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>org.eclipse.daanse.jdbc.datasource.testkit.clickhouse</artifactId>
+  <name>Daanse JDBC DataSource Test Kit — ClickHouse Provider</name>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.jdbc.datasource.testkit.api</artifactId>
+      <version>${revision}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.sql.dialect.db.clickhouse</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.clickhouse</groupId>
+      <artifactId>clickhouse-jdbc</artifactId>
+      <version>0.9.8</version>
+      <classifier>all</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>clickhouse</artifactId>
+      <version>1.21.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/testkit/clickhouse/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/clickhouse/ClickHouseDatabaseProvider.java
+++ b/testkit/clickhouse/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/clickhouse/ClickHouseDatabaseProvider.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena, Stefan Bischof - initial
+ */
+package org.eclipse.daanse.jdbc.datasource.testkit.clickhouse;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import javax.sql.DataSource;
+
+import org.eclipse.daanse.jdbc.datasource.testkit.api.ActiveDatabase;
+import org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider;
+import org.eclipse.daanse.sql.dialect.api.Dialect;
+import org.eclipse.daanse.sql.dialect.api.DialectInitData;
+import org.eclipse.daanse.sql.dialect.db.clickhouse.ClickHouseDialect;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+
+import com.clickhouse.jdbc.DataSourceImpl;
+
+/**
+ * ClickHouse provider backed by a shared Testcontainers container.
+ * <p>
+ * Replaces a hand-rolled docker-java provider that reached for ConfigurationAdmin
+ * to obtain its DataSource and therefore only worked inside an OSGi framework.
+ * Testcontainers needs no framework, which is what lets the suite run as plain
+ * JUnit.
+ * <p>
+ * {@link #activate(String)} isolates per key with {@code CREATE DATABASE};
+ * ClickHouse has no schema below the database, so the key names the database.
+ */
+public class ClickHouseDatabaseProvider implements DatabaseProvider {
+
+    private static final String IMAGE = "clickhouse/clickhouse-server:24.3";
+    private static final String DEFAULT_KEY = "__default__";
+
+    private static volatile ClickHouseContainer container;
+    private static final Object LOCK = new Object();
+
+    private final ConcurrentMap<String, ActiveDatabase> dbsByKey = new ConcurrentHashMap<>();
+
+    @Override
+    public String id() {
+        return "clickhouse";
+    }
+
+    @Override
+    public ActiveDatabase activate() {
+        return activate(DEFAULT_KEY);
+    }
+
+    @Override
+    public ActiveDatabase activate(String isolationKey) {
+        return dbsByKey.computeIfAbsent(isolationKey, this::newDatabaseForKey);
+    }
+
+    private ActiveDatabase newDatabaseForKey(String key) {
+        ClickHouseContainer c = sharedContainer();
+        String dbName = sanitize(key);
+        try (Connection admin = open(c, "default"); Statement st = admin.createStatement()) {
+            st.execute("CREATE DATABASE IF NOT EXISTS " + dbName);
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to create ClickHouse database " + dbName, e);
+        }
+        DataSource ds = dataSource(c, dbName);
+        Dialect dialect;
+        try (Connection conn = ds.getConnection()) {
+            dialect = new ClickHouseDialect(DialectInitData.fromConnection(conn));
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to build ClickHouse dialect for key " + key, e);
+        }
+        return new ActiveDatabase(ds, dialect);
+    }
+
+    private static DataSource dataSource(ClickHouseContainer c, String dbName) {
+        Properties props = new Properties();
+        props.setProperty("user", c.getUsername());
+        props.setProperty("password", c.getPassword());
+        return new DataSourceImpl(urlWithDatabase(c, dbName), props);
+    }
+
+    private static Connection open(ClickHouseContainer c, String dbName) throws SQLException {
+        return dataSource(c, dbName).getConnection();
+    }
+
+    /**
+     * The container hands out a URL pointing at the default database; the isolated
+     * database is selected by replacing the path.
+     */
+    private static String urlWithDatabase(ClickHouseContainer c, String dbName) {
+        String url = c.getJdbcUrl();
+        int lastSlash = url.lastIndexOf('/');
+        return lastSlash < 0 ? url + "/" + dbName : url.substring(0, lastSlash + 1) + dbName;
+    }
+
+    /** ClickHouse identifiers: letters, digits and underscore. */
+    private static String sanitize(String key) {
+        String cleaned = key.replaceAll("[^A-Za-z0-9_]", "_");
+        return cleaned.isEmpty() || Character.isDigit(cleaned.charAt(0)) ? "db_" + cleaned : cleaned;
+    }
+
+    private static ClickHouseContainer sharedContainer() {
+        ClickHouseContainer c = container;
+        if (c == null) {
+            synchronized (LOCK) {
+                c = container;
+                if (c == null) {
+                    ClickHouseContainer started = new ClickHouseContainer(IMAGE);
+                    started.start();
+                    container = started;
+                    c = started;
+                }
+            }
+        }
+        return c;
+    }
+}

--- a/testkit/clickhouse/src/main/resources/META-INF/services/org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider
+++ b/testkit/clickhouse/src/main/resources/META-INF/services/org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider
@@ -1,0 +1,1 @@
+org.eclipse.daanse.jdbc.datasource.testkit.clickhouse.ClickHouseDatabaseProvider

--- a/testkit/derby/pom.xml
+++ b/testkit/derby/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.jdbc.datasource.testkit</artifactId>
+    <version>${revision}</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>org.eclipse.daanse.jdbc.datasource.testkit.derby</artifactId>
+  <name>Daanse JDBC DataSource Test Kit — Derby Provider</name>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.jdbc.datasource.testkit.api</artifactId>
+      <version>${revision}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.sql.dialect.db.derby</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derby</artifactId>
+      <version>10.14.2.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/testkit/derby/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/derby/DerbyDatabaseProvider.java
+++ b/testkit/derby/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/derby/DerbyDatabaseProvider.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ */
+package org.eclipse.daanse.jdbc.datasource.testkit.derby;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.apache.derby.jdbc.EmbeddedDataSource;
+import org.eclipse.daanse.jdbc.datasource.testkit.api.ActiveDatabase;
+import org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider;
+import org.eclipse.daanse.sql.dialect.api.Dialect;
+import org.eclipse.daanse.sql.dialect.api.DialectInitData;
+import org.eclipse.daanse.sql.dialect.db.derby.DerbyDialect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Embedded Apache Derby, in-memory ({@code memory:foodmart-<UUID>}). The
+ * in-memory database lives for the whole JVM regardless of open connections.
+ */
+public class DerbyDatabaseProvider implements DatabaseProvider {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(DerbyDatabaseProvider.class);
+
+	private final String databaseName = "memory:foodmart-" + UUID.randomUUID();
+
+	@Override
+	public String id() {
+		return "derby";
+	}
+
+	@Override
+	public void close() {
+	}
+
+	/**
+	 * Derby reads these once, when the engine boots on the first connection, so they have to be
+	 * in place before {@link EmbeddedDataSource#getConnection()} is called. The page cache
+	 * defaults to 1000 pages (~4 MB) — FoodMart does not fit, so every aggregate scan walks back
+	 * through the pager. {@code durability=test} skips the log syncs, which buy nothing for a
+	 * database that lives and dies with the JVM.
+	 */
+	private static void bootProperties() {
+		setIfAbsent("derby.storage.pageCacheSize", "20000");
+		setIfAbsent("derby.system.durability", "test");
+		setIfAbsent("derby.language.statementCacheSize", "500");
+	}
+
+	private static void setIfAbsent(String key, String value) {
+		if (System.getProperty(key) == null) {
+			System.setProperty(key, value);
+		}
+	}
+
+	@Override
+	public ActiveDatabase activate() {
+		long tActivate = System.nanoTime();
+		bootProperties();
+		EmbeddedDataSource dataSource = new EmbeddedDataSource();
+		dataSource.setDatabaseName(databaseName);
+		dataSource.setCreateDatabase("create");
+		try {
+			Connection connection = dataSource.getConnection();
+			Dialect dialect = new DerbyDialect(DialectInitData.fromConnection(connection));
+			connection.close();
+			// embedded: db-ready = the (tiny) connect duration, for comparability with docker DBs
+			long ms = (System.nanoTime() - tActivate) / 1_000_000;
+			LOGGER.warn("DBTIMING db={} phase=db-ready ms={}", id(), ms);
+			LOGGER.warn("DBTIMING db={} phase=context-first ms={} detail=fresh,epoch={}", id(), ms,
+					System.currentTimeMillis() / 1000);
+			return new ActiveDatabase(dataSource, dialect);
+		} catch (SQLException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/testkit/derby/src/main/resources/META-INF/services/org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider
+++ b/testkit/derby/src/main/resources/META-INF/services/org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider
@@ -1,0 +1,1 @@
+org.eclipse.daanse.jdbc.datasource.testkit.derby.DerbyDatabaseProvider

--- a/testkit/duckdb/pom.xml
+++ b/testkit/duckdb/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.jdbc.datasource.testkit</artifactId>
+    <version>${revision}</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>org.eclipse.daanse.jdbc.datasource.testkit.duckdb</artifactId>
+  <name>Daanse JDBC DataSource Test Kit — DuckDB Provider</name>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.jdbc.datasource.testkit.api</artifactId>
+      <version>${revision}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.sql.dialect.db.duckdb</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.duckdb</groupId>
+      <artifactId>duckdb_jdbc</artifactId>
+      <version>1.5.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.18</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/testkit/duckdb/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/duckdb/DuckDbDatabaseProvider.java
+++ b/testkit/duckdb/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/duckdb/DuckDbDatabaseProvider.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ */
+package org.eclipse.daanse.jdbc.datasource.testkit.duckdb;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import javax.sql.DataSource;
+
+import org.duckdb.DuckDBConnection;
+import org.duckdb.DuckDBDriver;
+import org.eclipse.daanse.jdbc.datasource.testkit.api.ActiveDatabase;
+import org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider;
+import org.eclipse.daanse.sql.dialect.api.Dialect;
+import org.eclipse.daanse.sql.dialect.api.DialectInitData;
+import org.eclipse.daanse.sql.dialect.db.duckdb.DuckDbDialect;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Embedded DuckDB, in memory. Every {@code driver.connect("jdbc:duckdb:")} opens
+ * its own private, empty database, so this provider connects ONCE and hands out
+ * {@link DuckDBConnection#duplicate()} siblings of that connection — they all
+ * share the one in-memory database, and it lives as long as the keeper does.
+ *
+ * <p>
+ * The engine runs on its own defaults; system properties named
+ * {@code daanse.duckdb.<setting>} are passed through to it.
+ * </p>
+ */
+public class DuckDbDatabaseProvider implements DatabaseProvider {
+
+	// java.util.logging.Logger is imported for the DataSource shim below, so the
+	// slf4j class logger is declared with its fully qualified type.
+	private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(DuckDbDatabaseProvider.class);
+
+	private static final String URL = "jdbc:duckdb:";
+
+	/** Prefix of the system properties passed through to the engine. */
+	private static final String SETTING_PREFIX = "daanse.duckdb.";
+
+	@Override
+	public String id() {
+		return "duckdb";
+	}
+
+	private volatile DuckDbDataSource dataSource;
+
+	@Override
+	public void close() {
+		DuckDbDataSource ds = dataSource;
+		if (ds != null) {
+			// closing the keeper drops the in-memory database; there is no file to unlink
+			ds.close();
+		}
+	}
+
+	@Override
+	public ActiveDatabase activate() {
+		long tActivate = System.nanoTime();
+		DuckDbDataSource dataSource = new DuckDbDataSource(URL);
+		this.dataSource = dataSource;
+		try (Connection connection = dataSource.getConnection()) {
+			Dialect dialect = new DuckDbDialect(DialectInitData.fromConnection(connection));
+			// embedded: db-ready = the (tiny) connect duration, for comparability with docker DBs
+			long ms = (System.nanoTime() - tActivate) / 1_000_000;
+			LOGGER.warn("DBTIMING db={} phase=db-ready ms={}", id(), ms);
+			LOGGER.warn("DBTIMING db={} phase=context-first ms={} detail=fresh,epoch={}", id(), ms,
+					System.currentTimeMillis() / 1000);
+			return new ActiveDatabase(dataSource, dialect);
+		} catch (SQLException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * The DuckDB driver ships no {@link DataSource}; connect through
+	 * {@link DuckDBDriver#connect} directly (NOT {@code DriverManager}, which
+	 * does not work across OSGi class loaders).
+	 */
+	private static final class DuckDbDataSource implements DataSource {
+
+		private final DuckDBDriver driver = new DuckDBDriver();
+		private final String url;
+		private PrintWriter logWriter;
+		private int loginTimeout = 0;
+
+		/**
+		 * An embedded DuckDB database lives exactly as long as its last open
+		 * connection: closing it tears the database down. Callers here take a
+		 * connection per statement, so this one is held open for the provider's
+		 * lifetime - otherwise every query would pay a full database startup and
+		 * shutdown, which dwarfs the query itself.
+		 *
+		 * <p>
+		 * It is also the database every other connection duplicates, so it must be
+		 * the connection that carries the settings (see {@link #getConnection()}).
+		 */
+		private volatile DuckDBConnection keeper;
+
+		private DuckDbDataSource(String url) {
+			this.url = url;
+		}
+
+		private void close() {
+			DuckDBConnection k = keeper;
+			keeper = null;
+			if (k != null) {
+				try {
+					k.close();
+				} catch (SQLException e) {
+					LOGGER.warn("closing the duckdb keeper connection failed", e);
+				}
+			}
+		}
+
+		@Override
+		public Connection getConnection() throws SQLException {
+			Properties props = duckDbSettings();
+			if (keeper == null) {
+				synchronized (this) {
+					if (keeper == null) {
+						// The settings above only take effect on the connect that starts the
+						// database, so the keeper must carry them.
+						keeper = (DuckDBConnection) driver.connect(url, props);
+					}
+				}
+			}
+			// A fresh connect would open a fresh, empty in-memory database. duplicate()
+			// returns an independent connection onto the keeper's database.
+			return keeper.duplicate();
+		}
+
+		/**
+		 * Every {@code daanse.duckdb.<setting>} system property, passed on as
+		 * {@code <setting>}.
+		 *
+		 * <p>
+		 * Nothing is set otherwise, so an unconfigured provider starts DuckDB with
+		 * DuckDB's own defaults. Any setting the engine accepts can be given this
+		 * way - {@code -Ddaanse.duckdb.threads=2},
+		 * {@code -Ddaanse.duckdb.memory_limit=4GB}. They go in as connection
+		 * properties rather than a {@code SET} per connection, which would cost a
+		 * round trip on every checkout.
+		 * </p>
+		 *
+		 * <p>
+		 * One worth knowing about: {@code preserve_insertion_order=false} is faster,
+		 * but lets DuckDB return the rows of an unordered query in whatever order its
+		 * threads produce - which a caller comparing whole result strings cannot rely
+		 * on.
+		 * </p>
+		 */
+		private static Properties duckDbSettings() {
+			Properties props = new Properties();
+			for (String name : System.getProperties().stringPropertyNames()) {
+				if (name.startsWith(SETTING_PREFIX) && name.length() > SETTING_PREFIX.length()) {
+					String value = System.getProperty(name);
+					if (value != null && !value.isBlank()) {
+						props.setProperty(name.substring(SETTING_PREFIX.length()), value);
+					}
+				}
+			}
+			return props;
+		}
+
+		@Override
+		public Connection getConnection(String username, String password) throws SQLException {
+			// DuckDB is embedded — no authentication.
+			return getConnection();
+		}
+
+		@Override
+		public PrintWriter getLogWriter() throws SQLException {
+			return logWriter;
+		}
+
+		@Override
+		public void setLogWriter(PrintWriter out) throws SQLException {
+			this.logWriter = out;
+		}
+
+		@Override
+		public void setLoginTimeout(int seconds) throws SQLException {
+			this.loginTimeout = seconds;
+		}
+
+		@Override
+		public int getLoginTimeout() throws SQLException {
+			return loginTimeout;
+		}
+
+		@Override
+		public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+			return driver.getParentLogger();
+		}
+
+		@Override
+		public <T> T unwrap(Class<T> iface) throws SQLException {
+			if (iface.isInstance(this)) {
+				return iface.cast(this);
+			}
+			throw new SQLException("Cannot unwrap to " + iface.getName());
+		}
+
+		@Override
+		public boolean isWrapperFor(Class<?> iface) throws SQLException {
+			return iface.isInstance(this);
+		}
+	}
+
+}

--- a/testkit/duckdb/src/main/resources/META-INF/services/org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider
+++ b/testkit/duckdb/src/main/resources/META-INF/services/org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider
@@ -1,0 +1,1 @@
+org.eclipse.daanse.jdbc.datasource.testkit.duckdb.DuckDbDatabaseProvider

--- a/testkit/empty/pom.xml
+++ b/testkit/empty/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.jdbc.datasource.testkit</artifactId>
+    <version>${revision}</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>org.eclipse.daanse.jdbc.datasource.testkit.empty</artifactId>
+  <name>Daanse JDBC DataSource Test Kit — Empty Provider</name>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.jdbc.datasource.testkit.api</artifactId>
+      <version>${revision}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/testkit/empty/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/empty/EmptyDatabaseProvider.java
+++ b/testkit/empty/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/empty/EmptyDatabaseProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena, Stefan Bischof - initial
+ */
+package org.eclipse.daanse.jdbc.datasource.testkit.empty;
+
+import org.eclipse.daanse.jdbc.datasource.testkit.api.ActiveDatabase;
+import org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider;
+
+/**
+ * A provider without a database.
+ * <p>
+ * Selected like any other by id, it lets a suite run the cases that never touch
+ * JDBC without paying for a container or an embedded engine. {@link #activate()}
+ * returns {@code null} rather than an empty {@link ActiveDatabase}: there is no
+ * DataSource to hand out, and a caller that does reach for one should fail
+ * loudly instead of on a stub that pretends to work.
+ */
+public class EmptyDatabaseProvider implements DatabaseProvider {
+
+    @Override
+    public String id() {
+        return "empty";
+    }
+
+    @Override
+    public ActiveDatabase activate() {
+        return null;
+    }
+}

--- a/testkit/empty/src/main/resources/META-INF/services/org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider
+++ b/testkit/empty/src/main/resources/META-INF/services/org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider
@@ -1,0 +1,1 @@
+org.eclipse.daanse.jdbc.datasource.testkit.empty.EmptyDatabaseProvider

--- a/testkit/h2/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/h2/H2DatabaseProvider.java
+++ b/testkit/h2/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/h2/H2DatabaseProvider.java
@@ -53,7 +53,13 @@ public class H2DatabaseProvider implements DatabaseProvider {
 
     private ActiveDatabase newDatabase() {
         try {
-            String url = "jdbc:h2:memFS:" + UUID.randomUUID() + ";DATABASE_TO_UPPER=false";
+            // "mem" is h2's in-memory engine. The alternative, "memFS", puts a
+            // file-backed database on an in-memory file system, so every page still
+            // goes through the file layer for no gain here: both isolate by database
+            // name, and the name carries a UUID. Switchable with
+            // -Ddaanse.test.h2.scheme=memFS.
+            String scheme = System.getProperty("daanse.test.h2.scheme", "mem");
+            String url = "jdbc:h2:" + scheme + ":" + UUID.randomUUID() + ";DATABASE_TO_UPPER=false";
             JdbcDataSource ds = new JdbcDataSource();
             ds.setUrl(url);
             ds.setUser("sa");


### PR DESCRIPTION
rolap opens one physical connection per statement and nothing pooled them, so the TCK exhausted a different resource on each database: ephemeral ports on mariadb, server processes on oracle, table locks on sqlite.

- pools/api defines ConnectionPool as its own service type, with getConnection(Duration) and close(); pools/hikari implements it. Hikari wraps the DataSource directly, because MariaDB's PooledConnection never fires the close event a ConnectionPoolDataSource pool reclaims on.
- ActiveDatabase carries a pool beside its DataSource, so every provider is pooled by default and none of them had to change.
- duckdb, derby, clickhouse and empty complete the provider set; clickhouse is rewritten on Testcontainers, so no provider needs a running framework.
- Every provider runs on its database's own defaults. duckdb passes on any setting given as a daanse.duckdb.<setting> system property, h2 uses its plain in-memory engine, and the pool sizes are overridable per run.
