### PR TITLE
fix(testkit): grant the mysql and mariadb user privileges globally

### DIFF
--- a/testkit/mariadb/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/mariadb/MariaDbDatabaseProvider.java
+++ b/testkit/mariadb/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/mariadb/MariaDbDatabaseProvider.java
@@ -81,8 +81,10 @@ public class MariaDbDatabaseProvider implements DatabaseProvider {
         try (Connection admin = openAdmin(c); Statement st = admin.createStatement()) {
             st.execute("CREATE DATABASE IF NOT EXISTS `" + dbName + "`");
             // The container's own user has rights on the container's own database
-            // only, so it has to be granted them on each one created here.
+            // only. Granted here per database, and globally besides, so that a
+            // consumer can CREATE SCHEMA - a database on this server - of its own.
             st.execute("GRANT ALL PRIVILEGES ON `" + dbName + "`.* TO '" + c.getUsername() + "'@'%'");
+            st.execute("GRANT ALL PRIVILEGES ON *.* TO '" + c.getUsername() + "'@'%' WITH GRANT OPTION");
             st.execute("FLUSH PRIVILEGES");
         } catch (SQLException e) {
             throw new IllegalStateException("Failed to create MariaDB database " + dbName, e);

--- a/testkit/mysql/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/mysql/MySqlDatabaseProvider.java
+++ b/testkit/mysql/src/main/java/org/eclipse/daanse/jdbc/datasource/testkit/mysql/MySqlDatabaseProvider.java
@@ -82,8 +82,10 @@ public class MySqlDatabaseProvider implements DatabaseProvider {
         try (Connection admin = openAdmin(c); Statement st = admin.createStatement()) {
             st.execute("CREATE DATABASE IF NOT EXISTS `" + dbName + "`");
             // The container's own user has rights on the container's own database
-            // only, so it has to be granted them on each one created here.
+            // only. Granted here per database, and globally besides, so that a
+            // consumer can CREATE SCHEMA - a database on this server - of its own.
             st.execute("GRANT ALL PRIVILEGES ON `" + dbName + "`.* TO '" + c.getUsername() + "'@'%'");
+            st.execute("GRANT ALL PRIVILEGES ON *.* TO '" + c.getUsername() + "'@'%' WITH GRANT OPTION");
             st.execute("FLUSH PRIVILEGES");
         } catch (SQLException e) {
             throw new IllegalStateException("Failed to create MySQL database " + dbName, e);


### PR DESCRIPTION
Its rights ended at the databases created here, so a consumer could not create one of its own - which is what CREATE SCHEMA means on these servers.
