### PR TITLE
fix(pools): bind the named DataSource, match its read-only state

### DIFF
--- a/duckdb/src/main/java/org/eclipse/daanse/jdbc/datasource/duckdb/api/Constants.java
+++ b/duckdb/src/main/java/org/eclipse/daanse/jdbc/datasource/duckdb/api/Constants.java
@@ -59,4 +59,16 @@ public class Constants {
      */
     public static final String DATASOURCE_PROPERTY_READ_ONLY = "readOnly";
 
+    /**
+     * Constant for Properties of the Service that could be configured using the
+     * {@link Constants#PID_DATASOURCE}.
+     *
+     * Engine settings as {@code name=value}, passed to DuckDB as connection
+     * properties: {@code threads=2}, {@code memory_limit=4GB}, or anything else
+     * the engine accepts — deliberately not enumerated here.
+     *
+     * {@link org.eclipse.daanse.jdbc.datasource.duckdb.api.ocd.BaseConfig#settings()}
+     */
+    public static final String DATASOURCE_PROPERTY_SETTINGS = "settings";
+
 }

--- a/duckdb/src/main/java/org/eclipse/daanse/jdbc/datasource/duckdb/api/ocd/BaseConfig.java
+++ b/duckdb/src/main/java/org/eclipse/daanse/jdbc/datasource/duckdb/api/ocd/BaseConfig.java
@@ -31,6 +31,10 @@ public interface BaseConfig {
     String L10N_READ_ONLY_DESCRIPTION = L10N_PREFIX + Constants.DATASOURCE_PROPERTY_READ_ONLY
             + L10N_POSTFIX_DESCRIPTION;
 
+    String L10N_SETTINGS_NAME = L10N_PREFIX + Constants.DATASOURCE_PROPERTY_SETTINGS + L10N_POSTFIX_NAME;
+    String L10N_SETTINGS_DESCRIPTION = L10N_PREFIX + Constants.DATASOURCE_PROPERTY_SETTINGS
+            + L10N_POSTFIX_DESCRIPTION;
+
     // Default value constants
     String DEFAULT_DATABASE_NAME = "";
     boolean DEFAULT_READ_ONLY = false;
@@ -49,5 +53,14 @@ public interface BaseConfig {
             + "")
     default boolean readOnly() {
         return DEFAULT_READ_ONLY;
+    }
+
+    /**
+     * Engine settings as {@code name=value}, handed to DuckDB as connection
+     * properties ({@code threads}, {@code memory_limit}, ...).
+     */
+    @AttributeDefinition(name = L10N_SETTINGS_NAME, description = L10N_SETTINGS_DESCRIPTION, required = false)
+    default String[] settings() {
+        return new String[0];
     }
 }

--- a/duckdb/src/main/java/org/eclipse/daanse/jdbc/datasource/duckdb/impl/DataSourceService.java
+++ b/duckdb/src/main/java/org/eclipse/daanse/jdbc/datasource/duckdb/impl/DataSourceService.java
@@ -53,6 +53,12 @@ public class DataSourceService extends AbstractDataSource {
 
     @Deactivate
     public void deactivate() {
+        // Releases the database held by the DataSource's kept connection.
+        try {
+            ds.close();
+        } catch (SQLException e) {
+            LOGGER.warn("closing the duckdb database failed", e);
+        }
         LOGGER.debug("deactivated");
     }
 

--- a/duckdb/src/main/java/org/eclipse/daanse/jdbc/datasource/duckdb/impl/DuckDbDataSource.java
+++ b/duckdb/src/main/java/org/eclipse/daanse/jdbc/datasource/duckdb/impl/DuckDbDataSource.java
@@ -21,6 +21,7 @@ import java.util.logging.Logger;
 
 import javax.sql.DataSource;
 
+import org.duckdb.DuckDBConnection;
 import org.duckdb.DuckDBDriver;
 
 /**
@@ -28,12 +29,20 @@ import org.duckdb.DuckDBDriver;
  * DataSource implementation of its own, so connections are created through
  * {@link DuckDBDriver#connect(String, Properties)} (no {@code DriverManager} —
  * that would not work across OSGi class loaders).
+ * <p>
+ * One connection is opened and kept; every connection handed out is a
+ * {@link DuckDBConnection#duplicate()} of it. An in-memory DuckDB database
+ * belongs to the connection that opened it — a second {@code connect} would
+ * open a second, empty database.
  */
 public class DuckDbDataSource implements DataSource {
 
     private final DuckDBDriver driver = new DuckDBDriver();
     private final String url;
     private final Properties properties;
+
+    /** The connection that owns the database; held until {@link #close()}. */
+    private volatile DuckDBConnection keeper;
 
     private PrintWriter logWriter;
     private int loginTimeout = 0;
@@ -45,7 +54,31 @@ public class DuckDbDataSource implements DataSource {
 
     @Override
     public Connection getConnection() throws SQLException {
-        return driver.connect(url, properties);
+        DuckDBConnection held = keeper;
+        if (held == null) {
+            synchronized (this) {
+                if (keeper == null) {
+                    keeper = (DuckDBConnection) driver.connect(url, properties);
+                }
+                held = keeper;
+            }
+        }
+        return held.duplicate();
+    }
+
+    /**
+     * Releases the database. The next {@link #getConnection()} opens a new — for
+     * in-memory, empty — database, so call this only at the end of the component's life.
+     */
+    public void close() throws SQLException {
+        DuckDBConnection held;
+        synchronized (this) {
+            held = keeper;
+            keeper = null;
+        }
+        if (held != null) {
+            held.close();
+        }
     }
 
     /**

--- a/duckdb/src/main/java/org/eclipse/daanse/jdbc/datasource/duckdb/impl/Util.java
+++ b/duckdb/src/main/java/org/eclipse/daanse/jdbc/datasource/duckdb/impl/Util.java
@@ -12,6 +12,8 @@
 */
 package org.eclipse.daanse.jdbc.datasource.duckdb.impl;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -40,8 +42,29 @@ public class Util {
         if (booleanValue(configMap, Constants.DATASOURCE_PROPERTY_READ_ONLY, false)) {
             properties.setProperty(DuckDBDriver.DUCKDB_READONLY_PROPERTY, "true");
         }
+        // Passed through unread; an unknown setting is DuckDB's to reject.
+        for (String setting : settings(configMap)) {
+            int equals = setting.indexOf('=');
+            if (equals > 0) {
+                properties.setProperty(setting.substring(0, equals).trim(), setting.substring(equals + 1).trim());
+            }
+        }
 
         return new DuckDbDataSource(url, properties);
+    }
+
+    private static List<String> settings(Map<String, Object> configMap) {
+        Object value = configMap.get(Constants.DATASOURCE_PROPERTY_SETTINGS);
+        if (value instanceof String[] many) {
+            return List.of(many);
+        }
+        if (value instanceof Collection<?> collection) {
+            return collection.stream().map(String::valueOf).toList();
+        }
+        if (value instanceof String single && !single.isBlank()) {
+            return List.of(single);
+        }
+        return List.of();
     }
 
     private static String stringValue(Map<String, Object> configMap, String propName, String fallback) {

--- a/duckdb/src/main/resources/OSGI-INF/l10n/org.eclipse.daanse.jdbc.datasource.duckdb.ocd.properties
+++ b/duckdb/src/main/resources/OSGI-INF/l10n/org.eclipse.daanse.jdbc.datasource.duckdb.ocd.properties
@@ -10,3 +10,5 @@ databaseName.description=File path of the database for a persistent database, or
 
 readOnly.name=Read Only
 readOnly.description=Open the database in read-only mode (file databases only)
+settings.name=Engine settings
+settings.description=DuckDB settings as name=value, one per entry (threads, memory_limit, preserve_insertion_order, ...).

--- a/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/Constants.java
+++ b/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/Constants.java
@@ -62,6 +62,12 @@ public class Constants {
     public static final String POOL_PROPERTY_LEAK_THRESHOLD = "leakThreshold";
 
     /**
+     * Read-only state the pool puts a connection in. Has to match the DataSource:
+     * a driver that opened the database read-only refuses to leave that state.
+     */
+    public static final String POOL_PROPERTY_READ_ONLY = "readOnly";
+
+    /**
      * Tied to the OLAP engine's fan-out: {@code segmentCacheManagerNumberSqlThreads}
      * defaults to 100, so a single query may ask for that many connections at
      * once, and a smaller pool queues the engine's own threads before they reach
@@ -75,4 +81,5 @@ public class Constants {
     public static final long DEFAULT_IDLE_TIMEOUT = 600_000L;
     public static final long DEFAULT_MAX_LIFETIME = 1_800_000L;
     public static final long DEFAULT_LEAK_THRESHOLD = 300_000L;
+    public static final boolean DEFAULT_READ_ONLY = false;
 }

--- a/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/PoolSettings.java
+++ b/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/PoolSettings.java
@@ -25,33 +25,40 @@ import java.util.function.Consumer;
  *                      {@link Duration#ZERO} disables it
  */
 public record PoolSettings(String poolName, int maximumPoolSize, int minimumIdle, Duration connectionTimeout,
-        Duration idleTimeout, Duration maxLifetime, Duration leakThreshold) {
+        Duration idleTimeout, Duration maxLifetime, Duration leakThreshold, boolean readOnly) {
 
     /** Every value from {@link Constants}. */
     public static PoolSettings defaults() {
         return new PoolSettings("", Constants.DEFAULT_MAX_SIZE, Constants.DEFAULT_MIN_IDLE,
                 Duration.ofMillis(Constants.DEFAULT_ACQUIRE_TIMEOUT), Duration.ofMillis(Constants.DEFAULT_IDLE_TIMEOUT),
-                Duration.ofMillis(Constants.DEFAULT_MAX_LIFETIME), Duration.ofMillis(Constants.DEFAULT_LEAK_THRESHOLD));
+                Duration.ofMillis(Constants.DEFAULT_MAX_LIFETIME), Duration.ofMillis(Constants.DEFAULT_LEAK_THRESHOLD),
+                Constants.DEFAULT_READ_ONLY);
     }
 
     public PoolSettings withPoolName(String name) {
         return new PoolSettings(name, maximumPoolSize, minimumIdle, connectionTimeout, idleTimeout, maxLifetime,
-                leakThreshold);
+                leakThreshold, readOnly);
     }
 
     public PoolSettings withMaximumPoolSize(int size) {
-        return new PoolSettings(poolName, size, minimumIdle, connectionTimeout, idleTimeout, maxLifetime,
-                leakThreshold);
+        return new PoolSettings(poolName, size, minimumIdle, connectionTimeout, idleTimeout, maxLifetime, leakThreshold,
+                readOnly);
     }
 
     public PoolSettings withMinimumIdle(int idle) {
         return new PoolSettings(poolName, maximumPoolSize, idle, connectionTimeout, idleTimeout, maxLifetime,
-                leakThreshold);
+                leakThreshold, readOnly);
     }
 
     public PoolSettings withConnectionTimeout(Duration timeout) {
         return new PoolSettings(poolName, maximumPoolSize, minimumIdle, timeout, idleTimeout, maxLifetime,
-                leakThreshold);
+                leakThreshold, readOnly);
+    }
+
+    /** Has to match the DataSource; see {@link Constants#POOL_PROPERTY_READ_ONLY}. */
+    public PoolSettings withReadOnly(boolean readOnlyState) {
+        return new PoolSettings(poolName, maximumPoolSize, minimumIdle, connectionTimeout, idleTimeout, maxLifetime,
+                leakThreshold, readOnlyState);
     }
 
     /** As {@link #from(Map, Consumer)}, ignoring unreadable values. */
@@ -79,7 +86,16 @@ public record PoolSettings(String poolName, int maximumPoolSize, int minimumIdle
                 millis(config, Constants.POOL_PROPERTY_ACQUIRE_TIMEOUT, d.connectionTimeout(), onProblem),
                 millis(config, Constants.POOL_PROPERTY_IDLE_TIMEOUT, d.idleTimeout(), onProblem),
                 millis(config, Constants.POOL_PROPERTY_MAX_LIFETIME, d.maxLifetime(), onProblem),
-                millis(config, Constants.POOL_PROPERTY_LEAK_THRESHOLD, d.leakThreshold(), onProblem));
+                millis(config, Constants.POOL_PROPERTY_LEAK_THRESHOLD, d.leakThreshold(), onProblem),
+                bool(config, Constants.POOL_PROPERTY_READ_ONLY, d.readOnly()));
+    }
+
+    private static boolean bool(Map<String, Object> config, String key, boolean dflt) {
+        Object v = config.get(key);
+        if (v instanceof Boolean b) {
+            return b;
+        }
+        return v == null ? dflt : Boolean.parseBoolean(v.toString().trim());
     }
 
     private static String string(Map<String, Object> config, String key, String dflt) {

--- a/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/ocd/BaseConfig.java
+++ b/pools/api/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/api/ocd/BaseConfig.java
@@ -47,6 +47,8 @@ public interface BaseConfig {
     String L10N_LEAK_THRESHOLD_NAME = L10N_PREFIX + Constants.POOL_PROPERTY_LEAK_THRESHOLD + L10N_POSTFIX_NAME;
     String L10N_LEAK_THRESHOLD_DESCRIPTION = L10N_PREFIX + Constants.POOL_PROPERTY_LEAK_THRESHOLD
             + L10N_POSTFIX_DESCRIPTION;
+    String L10N_READ_ONLY_NAME = L10N_PREFIX + Constants.POOL_PROPERTY_READ_ONLY + L10N_POSTFIX_NAME;
+    String L10N_READ_ONLY_DESCRIPTION = L10N_PREFIX + Constants.POOL_PROPERTY_READ_ONLY + L10N_POSTFIX_DESCRIPTION;
 
     @AttributeDefinition(name = L10N_POOL_NAME_NAME, description = L10N_POOL_NAME_DESCRIPTION, required = false)
     default String poolName() {
@@ -81,5 +83,10 @@ public interface BaseConfig {
     @AttributeDefinition(name = L10N_LEAK_THRESHOLD_NAME, description = L10N_LEAK_THRESHOLD_DESCRIPTION, required = false)
     default long leakThreshold() {
         return Constants.DEFAULT_LEAK_THRESHOLD;
+    }
+
+    @AttributeDefinition(name = L10N_READ_ONLY_NAME, description = L10N_READ_ONLY_DESCRIPTION, required = false)
+    default boolean readOnly() {
+        return Constants.DEFAULT_READ_ONLY;
     }
 }

--- a/pools/hikari/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/hikari/impl/HikariConnectionPool.java
+++ b/pools/hikari/src/main/java/org/eclipse/daanse/jdbc/datasource/pools/hikari/impl/HikariConnectionPool.java
@@ -27,8 +27,8 @@ import java.util.concurrent.TimeoutException;
 import javax.sql.DataSource;
 
 import org.eclipse.daanse.jdbc.datasource.pools.api.ConnectionPool;
-import org.eclipse.daanse.jdbc.datasource.pools.api.PoolSettings;
 import org.eclipse.daanse.jdbc.datasource.pools.api.Constants;
+import org.eclipse.daanse.jdbc.datasource.pools.api.PoolSettings;
 import org.eclipse.daanse.jdbc.datasource.pools.hikari.api.ocd.DsConfig;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -75,7 +75,11 @@ public class HikariConnectionPool implements ConnectionPool {
      * names.
      */
     @Activate
-    public HikariConnectionPool(@Reference DataSource dataSource, Map<String, Object> config) {
+    // The compiled class keeps no parameter names; unnamed, the reference becomes
+    // "$000" and the dataSource.target property silently filters nothing.
+    public HikariConnectionPool(
+            @Reference(name = "dataSource") DataSource dataSource,
+            Map<String, Object> config) {
         this(dataSource, PoolSettings.from(config, LOGGER::warn));
     }
 
@@ -88,6 +92,9 @@ public class HikariConnectionPool implements ConnectionPool {
         cfg.setConnectionTimeout(settings.connectionTimeout().toMillis());
         cfg.setIdleTimeout(settings.idleTimeout().toMillis());
         cfg.setMaxLifetime(settings.maxLifetime().toMillis());
+        // Has to match how the DataSource opened the database; a read-only driver
+        // refuses to leave that state.
+        cfg.setReadOnly(settings.readOnly());
         // Reports a connection held longer than this; unlike dbcp2 hikari never takes
         // it back, so this is a warning about a caller that forgot to close, nothing more.
         cfg.setLeakDetectionThreshold(settings.leakThreshold().toMillis());

--- a/pools/hikari/src/main/resources/OSGI-INF/l10n/org.eclipse.daanse.jdbc.datasource.pools.hikari.ocd.properties
+++ b/pools/hikari/src/main/resources/OSGI-INF/l10n/org.eclipse.daanse.jdbc.datasource.pools.hikari.ocd.properties
@@ -16,3 +16,5 @@ maxLifetime.name=Maximum lifetime (ms)
 maxLifetime.description=A connection is retired this long after it was opened.
 leakThreshold.name=Leak report threshold (ms)
 leakThreshold.description=A connection held longer than this is reported. HikariCP only warns and never takes it back; use the dbcp2 pool if connections must be reclaimed.
+readOnly.name=Read-only connections
+readOnly.description=State the pool puts every connection in; has to match how the DataSource opened the database.


### PR DESCRIPTION
hikari: name the dataSource reference so dataSource.target filters again.
pools: readOnly setting; must match the DataSource.
duckdb: engine settings pass-through; one kept connection for in-memory.
testkit: grant the mysql and mariadb user globally, so CREATE SCHEMA works.


